### PR TITLE
Add 'favourite' to RoomResponse

### DIFF
--- a/library/core/src/main/java/com/amatkivskiy/gitter/sdk/model/response/room/RoomResponse.java
+++ b/library/core/src/main/java/com/amatkivskiy/gitter/sdk/model/response/room/RoomResponse.java
@@ -22,6 +22,7 @@ public class RoomResponse {
   @SerializedName("noindex") public final boolean noIndex;
   @SerializedName("tags") public final List<String> tags = new ArrayList<String>();
   @SerializedName("v") public final int v;
+  @SerializedName("favourite") public final int favourite;
 
   public RoomResponse(String id,
                       String name,
@@ -37,7 +38,8 @@ public class RoomResponse {
                       RoomType githubRoomType,
                       String security,
                       boolean noIndex,
-                      int v) {
+                      int v,
+                      int favourite) {
     this.id = id;
     this.name = name;
     this.topic = topic;
@@ -53,5 +55,6 @@ public class RoomResponse {
     this.security = security;
     this.noIndex = noIndex;
     this.v = v;
+    this.favourite = favourite;
   }
 }


### PR DESCRIPTION
Hi there! I noticed that the Gitter API provides an optional 'favourite' key, and figured that it should be handled by RoomResponse. I've tested this change locally.
