### PR TITLE
Added rooms/:roomId/users query parameters to client API

### DIFF
--- a/library/async/src/main/java/com/amatkivskiy/gitter/sdk/async/api/AsyncGitterApi.java
+++ b/library/async/src/main/java/com/amatkivskiy/gitter/sdk/async/api/AsyncGitterApi.java
@@ -50,6 +50,9 @@ public interface AsyncGitterApi {
   @GET("/rooms/{roomId}/users")
   void getRoomUsers(@Path("roomId") String roomId, Callback<List<UserResponse>> callback);
 
+  @GET("/rooms/{roomId}/users")
+  void getRoomUsers(@Path("roomId") String roomId, @Query("q") String query, @Query("skip") int skip, @Query("limit") int limit, Callback<List<UserResponse>> callback);
+
   @GET("/rooms/{roomId}/channels")
   void getRoomChannels(@Path("roomId") String roomId, Callback<List<RoomResponse>> callback);
 

--- a/library/async/src/main/java/com/amatkivskiy/gitter/sdk/async/client/AsyncGitterApiClient.java
+++ b/library/async/src/main/java/com/amatkivskiy/gitter/sdk/async/client/AsyncGitterApiClient.java
@@ -65,6 +65,10 @@ public class AsyncGitterApiClient {
     api.getRoomUsers(roomId, callback);
   }
 
+  public void getRoomUsers(String roomId, String query, int skip, int limit, Callback<List<UserResponse>> callback) {
+    api.getRoomUsers(roomId, query, skip, limit, callback);
+  }
+
   public void getRoomChannels(String roomId, Callback<List<RoomResponse>> callback) {
     api.getRoomChannels(roomId, callback);
   }

--- a/library/rx/build.gradle
+++ b/library/rx/build.gradle
@@ -30,4 +30,7 @@ dependencies {
     compile 'com.github.amatkivskiy:gitter.sdk.core:1.5'
 //    compile project(':library:core')
     compile 'io.reactivex:rxjava:1.0.10'
+
+    testCompile 'junit:junit:4.12'
+    testCompile 'org.hamcrest:hamcrest-library:1.3'
 }

--- a/library/rx/src/main/java/com/amatkivskiy/gitter/sdk/rx/api/RxGitterApi.java
+++ b/library/rx/src/main/java/com/amatkivskiy/gitter/sdk/rx/api/RxGitterApi.java
@@ -51,6 +51,9 @@ public interface RxGitterApi {
   @GET("/rooms/{roomId}/users")
   Observable<List<UserResponse>> getRoomUsers(@Path("roomId") String roomId);
 
+  @GET("/rooms/{roomId}/users")
+  Observable<List<UserResponse>> getRoomUsers(@Path("roomId") String roomId, @Query("q") String query, @Query("skip") int skip, @Query("limit") int limit);
+
   @GET("/rooms/{roomId}/channels")
   Observable<List<RoomResponse>> getRoomChannels(@Path("roomId") String roomId);
 

--- a/library/rx/src/main/java/com/amatkivskiy/gitter/sdk/rx/client/RxGitterApiClient.java
+++ b/library/rx/src/main/java/com/amatkivskiy/gitter/sdk/rx/client/RxGitterApiClient.java
@@ -64,6 +64,10 @@ public class RxGitterApiClient {
     return api.getRoomUsers(roomId);
   }
 
+  public Observable<List<UserResponse>> getRoomUsers(String roomId, String query, int skip, int limit) {
+    return api.getRoomUsers(roomId, query, skip, limit);
+  }
+
   public Observable<List<RoomResponse>> getRoomChannels(String roomId) {
     return api.getRoomChannels(roomId);
   }

--- a/library/rx/src/test/java/RoomUsersUnitTest.java
+++ b/library/rx/src/test/java/RoomUsersUnitTest.java
@@ -1,0 +1,102 @@
+import com.amatkivskiy.gitter.sdk.model.response.UserResponse;
+import com.amatkivskiy.gitter.sdk.model.response.room.RoomResponse;
+import com.amatkivskiy.gitter.sdk.rx.client.RxGitterApiClient;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import rx.Observable;
+import rx.functions.Func1;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.core.IsNot.not;
+
+public class RoomUsersUnitTest {
+
+    private static final String ACCESS_TOKEN = "your_access_token";
+    private static final String ROOM_ID = "room_id";
+    private static final boolean GET_RANDOM_ROOM = true;
+
+    private RxGitterApiClient client;
+    private String roomId;
+
+    //Setup client, roomId for each test
+    @Before
+    public void setUp() {
+        client = new RxGitterApiClient.Builder()
+                .withAccountToken(ACCESS_TOKEN)
+                .build();
+
+        if (!GET_RANDOM_ROOM) {
+            roomId = ROOM_ID;
+            return;
+        }
+
+        //Get one room
+        RoomResponse roomResponse = client.getCurrentUserRooms()
+                .flatMap(new Func1<List<RoomResponse>, Observable<RoomResponse>>() {
+                    @Override
+                    public Observable<RoomResponse> call(List<RoomResponse> roomResponses) {
+                        return Observable.from(roomResponses);
+                    }
+                })
+                .take(1)
+                .toBlocking()
+                .first();
+
+        roomId = roomResponse.id;
+    }
+
+    @Test
+    public void query_users_in_room_test() {
+        //Search Users in Room querying display name
+        String query = "and";
+        int skip = 0;
+        int limit = 30;
+        List<UserResponse> usersInRoomThatStartWithQuery =
+                client.getRoomUsers(roomId, query, skip, limit).
+                        toBlocking()
+                        .first();
+
+
+        //All users found must have "query" in display name
+        for (UserResponse userResponse : usersInRoomThatStartWithQuery) {
+            assertThat(userResponse.displayName.toLowerCase().contains(query), is(true));
+        }
+    }
+
+    @Test
+    public void limit_users_in_room_test() {
+        //Get Users in Room but Limit result
+        String query = null;
+        int skip = 0;
+        int limit = 5;
+        List<UserResponse> usersInRoom =
+                client.getRoomUsers(roomId, query, skip, limit)
+                        .toBlocking()
+                        .first();
+
+
+        //Result must bring "limit" records
+        assertThat(usersInRoom.size(), is(limit));
+    }
+
+    @Test
+    public void skip_users_in_room_test() {
+        //Get 1 user from room
+        UserResponse firstUser = client.getRoomUsers(roomId, null, 0, 0).toBlocking().first().get(0);
+
+        //Get 1 user from room skipping 0
+        UserResponse sameFirstUser = client.getRoomUsers(roomId, null, 0, 0).toBlocking().first().get(0);
+
+        //Get 1 user from room skipping 1
+        UserResponse nextUser = client.getRoomUsers(roomId, null, 1, 0).toBlocking().first().get(0);
+
+        assertThat(firstUser.id, is(sameFirstUser.id));
+        assertThat(nextUser.id, not(firstUser.id));
+        assertThat(nextUser.id, not(sameFirstUser.id));
+    }
+}

--- a/library/sync/src/main/java/com/amatkivskiy/gitter/sdk/sync/api/SyncGitterApi.java
+++ b/library/sync/src/main/java/com/amatkivskiy/gitter/sdk/sync/api/SyncGitterApi.java
@@ -49,6 +49,9 @@ public interface SyncGitterApi {
   @GET("/rooms/{roomId}/users")
   List<UserResponse> getRoomUsers(@Path("roomId") String roomId);
 
+  @GET("/rooms/{roomId}/users")
+  List<UserResponse> getRoomUsers(@Path("roomId") String roomId, @Query("q") String query, @Query("skip") int skip, @Query("limit") int limit);
+
   @GET("/rooms/{roomId}/channels")
   List<RoomResponse> getRoomChannels(@Path("roomId") String roomId);
 

--- a/library/sync/src/main/java/com/amatkivskiy/gitter/sdk/sync/client/SyncGitterApiClient.java
+++ b/library/sync/src/main/java/com/amatkivskiy/gitter/sdk/sync/client/SyncGitterApiClient.java
@@ -62,6 +62,10 @@ public class SyncGitterApiClient {
     return api.getRoomUsers(roomId);
   }
 
+  public List<UserResponse> getRoomUsers(String roomId, String query, int skip, int limit) {
+    return api.getRoomUsers(roomId, query, skip, limit);
+  }
+
   public List<RoomResponse> getRoomChannels(String roomId) {
     return api.getRoomChannels(roomId);
   }


### PR DESCRIPTION
Only for Rx version.

1) Added query parameters to client api.
- q: Search query
- skip: Skip n users.
- limit: maximum number of users to return (default 30).

2) Added test dependencies
- JUnit
- Hamcrest

3) Added tests for new api. Tests available in rx/src/test/java
