### PR TITLE
Added Java 7 compilation flags

### DIFF
--- a/library/async/build.gradle
+++ b/library/async/build.gradle
@@ -1,6 +1,9 @@
 apply plugin: 'java'
 apply plugin: 'com.novoda.bintray-release'
 
+targetCompatibility = '1.7'
+sourceCompatibility = '1.7'
+
 buildscript {
     repositories {
         jcenter()

--- a/library/core/build.gradle
+++ b/library/core/build.gradle
@@ -1,6 +1,9 @@
 apply plugin: 'java'
 apply plugin: 'com.novoda.bintray-release'
 
+targetCompatibility = '1.7'
+sourceCompatibility = '1.7'
+
 version '1.5'
 
 buildscript {

--- a/library/rx/build.gradle
+++ b/library/rx/build.gradle
@@ -3,6 +3,9 @@ apply plugin: 'com.novoda.bintray-release'
 apply plugin: 'jacoco'
 apply plugin: 'com.github.kt3k.coveralls'
 
+targetCompatibility = '1.7'
+sourceCompatibility = '1.7'
+
 buildscript {
     repositories {
         jcenter()

--- a/library/sync/build.gradle
+++ b/library/sync/build.gradle
@@ -1,6 +1,9 @@
 apply plugin: 'java'
 apply plugin: 'com.novoda.bintray-release'
 
+targetCompatibility = '1.7'
+sourceCompatibility = '1.7'
+
 buildscript {
     repositories {
         jcenter()


### PR DESCRIPTION
Java 8 is not fully supported in Android Studio when using features like Data Binding. 

If a project uses Data Binding, Java 7 is the preferred compiler since Jack compiles (Java 8) does not behave well with Data Binding. If Java 7 is used, GitterJavaSDK cannot be included as a local module in another Android Project.
