### PR TITLE
Refactored request params.

### DIFF
--- a/library/core/src/main/java/com/amatkivskiy/gitter/sdk/model/request/BasicRequestParams.java
+++ b/library/core/src/main/java/com/amatkivskiy/gitter/sdk/model/request/BasicRequestParams.java
@@ -1,0 +1,38 @@
+package com.amatkivskiy.gitter.sdk.model.request;
+
+public class BasicRequestParams {
+  public final Integer skipCount;
+  public final String searchQuery;
+  public final Integer limit;
+
+  public BasicRequestParams(Integer skipCount, String searchQuery, Integer limit) {
+    this.skipCount = skipCount;
+    this.searchQuery = searchQuery;
+    this.limit = limit;
+  }
+
+  public static class BasicRequestParamsBuilder {
+    private Integer skipCount;
+    private String searchQuery;
+    private Integer limit;
+
+    public BasicRequestParamsBuilder skipCount(Integer skipCount) {
+      this.skipCount = skipCount;
+      return this;
+    }
+
+    public BasicRequestParamsBuilder searchQuery(String searchQuery) {
+      this.searchQuery = searchQuery;
+      return this;
+    }
+
+    public BasicRequestParamsBuilder limit(Integer limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    public BasicRequestParams build() {
+      return new BasicRequestParams(skipCount, searchQuery, limit);
+    }
+  }
+}

--- a/library/core/src/main/java/com/amatkivskiy/gitter/sdk/model/request/ChatMessagesRequestParams.java
+++ b/library/core/src/main/java/com/amatkivskiy/gitter/sdk/model/request/ChatMessagesRequestParams.java
@@ -1,21 +1,16 @@
 package com.amatkivskiy.gitter.sdk.model.request;
 
-public class ChatMessagesRequestParams {
-  public final Integer skipCount;
+public class ChatMessagesRequestParams extends BasicRequestParams {
   public final String beforeId;
   public final String afterId;
   public final String aroundId;
-  public final String searchQuery;
-  public final Integer limit;
 
   private ChatMessagesRequestParams(Integer skipCount, String beforeId, String afterId,
                                     String aroundId, String searchQuery, Integer limit) {
-    this.skipCount = skipCount;
+    super(skipCount, searchQuery, limit);
     this.beforeId = beforeId;
     this.afterId = afterId;
     this.aroundId = aroundId;
-    this.searchQuery = searchQuery;
-    this.limit = limit;
   }
 
   public static class ChatMessagesRequestParamsBuilder {

--- a/library/core/src/main/java/com/amatkivskiy/gitter/sdk/util/RequestUtils.java
+++ b/library/core/src/main/java/com/amatkivskiy/gitter/sdk/util/RequestUtils.java
@@ -2,18 +2,15 @@ package com.amatkivskiy.gitter.sdk.util;
 
 import com.amatkivskiy.gitter.sdk.Constants;
 import com.amatkivskiy.gitter.sdk.model.request.ChatMessagesRequestParams;
+import com.amatkivskiy.gitter.sdk.model.request.BasicRequestParams;
 
 import java.util.HashMap;
 
 public class RequestUtils {
-  public static HashMap<String, String> convertChatMessagesParamsToMap(
-      ChatMessagesRequestParams params) {
-    HashMap<String, String> options = new HashMap<>();
-    if (params != null) {
-      if (params.limit != null) {
-        options.put(Constants.GitterRequestParams.LIMIT_PARAM, String.valueOf(params.limit.intValue()));
-      }
+  public static HashMap<String, String> convertChatMessagesParamsToMap(ChatMessagesRequestParams params) {
+    HashMap<String, String> options = convertBasicRequestParamsToMap(params);
 
+    if (params != null) {
       if (params.afterId != null) {
         options.put(Constants.GitterRequestParams.AFTER_ID_PARAM, params.afterId);
       }
@@ -22,12 +19,23 @@ public class RequestUtils {
         options.put(Constants.GitterRequestParams.BEFORE_ID_PARAM, params.beforeId);
       }
 
-      if (params.skipCount != null) {
-        options.put(Constants.GitterRequestParams.SKIP_PARAM, String.valueOf(params.skipCount.intValue()));
-      }
-
       if (params.aroundId != null) {
         options.put(Constants.GitterRequestParams.AROUND_ID_PARAM, params.aroundId);
+      }
+    }
+
+    return options;
+  }
+
+  public static HashMap<String, String> convertBasicRequestParamsToMap(BasicRequestParams params) {
+    HashMap<String, String> options = new HashMap<>();
+    if (params != null) {
+      if (params.limit != null) {
+        options.put(Constants.GitterRequestParams.LIMIT_PARAM, String.valueOf(params.limit.intValue()));
+      }
+
+      if (params.skipCount != null) {
+        options.put(Constants.GitterRequestParams.SKIP_PARAM, String.valueOf(params.skipCount.intValue()));
       }
 
       if (params.searchQuery != null) {


### PR DESCRIPTION
Extracted common request params so it will be possible to use them in other requests which accept this params (not only chat messages request).

Now @asantibanez you can use `BasicRequestParams` for the search room users request.
