### PR TITLE
Change okio version to match okhttp dependency

### DIFF
--- a/library/async/build.gradle
+++ b/library/async/build.gradle
@@ -32,6 +32,6 @@ dependencies {
 //    compile project(':library:core')
     compile 'com.github.amatkivskiy:gitter.sdk.core:1.6.0'
 
-    compile 'com.squareup.okio:okio:1.6.0'
+    compile 'com.squareup.okio:okio:1.11.0'
     compile 'com.squareup.okhttp3:okhttp:3.5.0'
 }


### PR DESCRIPTION
This prevents an eviction of 1.11.0 when using SBT as the build tool of choice. 

Otherwise the below is required

```
libraryDependencies += "com.github.amatkivskiy" % "gitter.sdk.async" % "1.6.0"
dependencyOverrides += "com.squareup.okio" % "okio" % "1.11.0"
```

Basically its a conflict where async depends on 1.6, okhttp depends on 1.11. So depending on what the build tools default behaviour is, one or the other will be evicted.